### PR TITLE
add appendPathSegments and mapPath

### DIFF
--- a/Erl.elm
+++ b/Erl.elm
@@ -11,6 +11,8 @@ module Erl (
   parse,
   removeQuery,
   setQuery,
+  mapPath,
+  appendPathSegments,
   toString,
   Url,
   Query
@@ -31,7 +33,7 @@ module Erl (
 @docs new, toString
 
 # Mutation helpers
-@docs addQuery, setQuery, removeQuery, clearQuery
+@docs addQuery, setQuery, removeQuery, clearQuery, mapPath, appendPathSegments
 
 -}
 
@@ -466,6 +468,27 @@ removeQuery key url =
       Dict.remove key url.query
   in
     {url | query = updated }
+
+{-| Transform a url's path with a function
+    
+    Erl.mapPath f url
+-}
+mapPath: (List String -> List String) -> Url -> Url
+mapPath f url =
+  let
+    updated =
+      f (url.path)
+  in
+    {url | path = updated }
+
+{-| Append some path segments to a url
+    
+    Erl.appendPathSegments segments url
+-}
+appendPathSegments: (List String) -> Url -> Url
+appendPathSegments segments =
+  mapPath (\oldSegments -> oldSegments ++ segments)
+
 
 {-| Generate url string from an Erl.Url record
 

--- a/Tests.elm
+++ b/Tests.elm
@@ -167,6 +167,41 @@ testPath =
     suite "Path"
       (List.map run inputs)
 
+testMapPath: Test
+testMapPath =
+  let
+    f segments = ["start"] ++ segments ++ ["end"]
+    inputs =
+      [
+        ("http://foo.com/users/index.html?a=1", ["start", "users", "index.html", "end"]),
+        ("/", ["start", "end"])
+      ]
+    run (input, expected) =
+      test "Transforms the path"
+        (assertEqual expected (Erl.mapPath f (Erl.parse input)).path)
+  in
+    suite "mapPath"
+      (List.map run inputs)
+
+testAppendPathSegments: Test
+testAppendPathSegments =
+  let
+    inputs =
+      [
+        ("http://foo.com/users/index.html?a=1", ["extra"], ["users", "index.html", "extra"]),
+        ("/", [], []),
+        ("/zero", ["one", "two"], ["zero", "one", "two"])
+      ]
+    run (inputUrl, inputPathSegments, expected) =
+      test "Appends segments to the path"
+        (assertEqual expected (Erl.appendPathSegments inputPathSegments (Erl.parse inputUrl)).path)
+  in
+    suite "appendPathSegments"
+      (List.map run inputs)
+
+
+
+
 -- FRAGMENT
 
 testHashExtract =
@@ -402,6 +437,8 @@ all =
       testNew,
       testPath,
       testPathExtract,
+      testMapPath,
+      testAppendPathSegments,
       testPort,
       testPortExtract,
       testProtocol,


### PR DESCRIPTION
We briefly discussed these in elm-lang slack. I wrote them to construct URLs for various API endpoints, and am wondering if it makes sense for them to be in the library itself. I had more uses of the map function at one stage, but now its only consumer is the append function. I'm not sure if that means we should fold it in or if it makes sense to expose both.

I'm completely happy to keep these in my codebase if they don't make sense to you as part of the library, by the way.

Thanks!
