### PR TITLE
Handle trailing slashes in parse and toString

### DIFF
--- a/Erl.elm
+++ b/Erl.elm
@@ -63,6 +63,7 @@ type alias Url = {
   host: List String,
   port': Int,
   path: List String,
+  hasTrailingSlash: Bool,
   hash: String,
   query: Query
 }
@@ -238,6 +239,10 @@ parsePath str =
 pathFromAll: String -> List String
 pathFromAll str =
   parsePath (extractPath str)
+  
+hasTrailingSlashFromAll: String -> Bool
+hasTrailingSlashFromAll str =
+    Regex.contains (Regex.regex "/$") (extractPath str)
 
 -- FRAGMENT
 
@@ -322,6 +327,7 @@ parse str =
     hash = (hashFromAll str),
     password = "",
     path = (pathFromAll str),
+    hasTrailingSlash = (hasTrailingSlashFromAll str),
     port' = (extractPort str),
     protocol = (extractProtocol str),
     query = (queryFromAll str),
@@ -380,6 +386,14 @@ pathComponent url =
     else
       "/" ++ (join "/" encoded)
 
+trailingSlashComponent: Url -> String
+trailingSlashComponent url =
+  if url.hasTrailingSlash == True then
+    "/"
+  else
+    ""
+
+
 {-| Convert to a string the hash component of an url, this includes '#'
 
     queryToString url == "#a/b"
@@ -415,6 +429,7 @@ new =
     password = "",
     host = [],
     path = [],
+    hasTrailingSlash = False,
     port' = 0,
     hash = "",
     query = Dict.empty
@@ -506,11 +521,13 @@ toString url =
       portComponent url
     path' =
       pathComponent url
+    trailingSlash' =
+      trailingSlashComponent url
     query' =
       queryToString url
     hash =
       hashToString url
   in
-    protocol' ++ host' ++ port' ++ path' ++ query' ++ hash
+    protocol' ++ host' ++ port' ++ path' ++ trailingSlash' ++ query' ++ hash
 
 

--- a/Tests.elm
+++ b/Tests.elm
@@ -166,6 +166,21 @@ testPath =
   in
     suite "Path"
       (List.map run inputs)
+      
+testHasTrailingSlash: Test
+testHasTrailingSlash =
+  let
+    inputs =
+      [
+        ("http://foo.com/users/all/?a=1", True),
+        ("http://foo.com/users/all?a=1", False)
+      ]
+    run (input, expected) =
+      test "Identifies the presence of a trailing slash"
+        (assertEqual expected (Erl.parse input).hasTrailingSlash)
+  in
+    suite "Path"
+      (List.map run inputs)
 
 testAppendPathSegments: Test
 testAppendPathSegments =
@@ -297,6 +312,7 @@ testToString =
         password = "",
         host = ["www", "foo", "com"],
         path = ["users", "1"],
+        hasTrailingSlash = False,
         port' = 2000,
         hash = "a/b",
         query = Dict.empty |> Dict.insert "q" "1" |> Dict.insert "k" "2"
@@ -309,6 +325,7 @@ testToString =
         host = [],
         port' = 0,
         path = [],
+        hasTrailingSlash = False,
         hash = "",
         query = Dict.empty
       }
@@ -318,6 +335,11 @@ testToString =
           "it converts to string",
           url1,
           "http://www.foo.com:2000/users/1?k=2&q=1#a/b"
+        ),
+        (
+          "it can have a trailing slash",
+          {url1 | hasTrailingSlash = True},
+          "http://www.foo.com:2000/users/1/?k=2&q=1#a/b"
         ),
         (
           "it can have an empty protocol",
@@ -411,6 +433,7 @@ testNew =
         host = [],
         port' = 0,
         path = [],
+        hasTrailingSlash = False,
         hash = "",
         query = Dict.empty
       }
@@ -506,6 +529,7 @@ all =
       testNew,
       testPath,
       testPathExtract,
+      testHasTrailingSlash,
       testPort,
       testPortExtract,
       testProtocol,


### PR DESCRIPTION
This adds handling for trailing slashes. For documentation: we opted for `hasTrailingSlash` over simply keeping `""` in path segments because a lot of unexpected things can come up once you start working path segments that contain `""`.
