### PR TITLE
Ignore default HTTPS port Erl.toString.

### DIFF
--- a/src/Erl.elm
+++ b/src/Erl.elm
@@ -238,7 +238,8 @@ extractHost str =
     -- if str starts with // or contains :// then we can assume that what follows is the host
     -- if it doesn't then look for tld
     let
-        delim = schemeHostDelim str
+        delim =
+            schemeHostDelim str
     in
         case delim of
             Just delim ->
@@ -506,6 +507,12 @@ portComponent url =
 
         80 ->
             ""
+
+        443 ->
+            if url.protocol == "https" then
+                ""
+            else
+                ":443"
 
         _ ->
             ":" ++ (Basics.toString url.port_)

--- a/src/ErlTests.elm
+++ b/src/ErlTests.elm
@@ -427,6 +427,10 @@ testToString =
               , { url1 | port_ = 80 }
               , "http://www.foo.com/users/1?q=1&k=2#a/b"
               )
+            , ( "it doesn't include the port when it is 443 and the protocol is https"
+              , { url1 | protocol = "https", port_ = 443 }
+              , "https://www.foo.com/users/1?q=1&k=2#a/b"
+              )
             , ( "it doesn't add # when hash is empty"
               , { url1 | hash = "" }
               , "http://www.foo.com:2000/users/1?q=1&k=2"


### PR DESCRIPTION
Hi! :wave: thanks a lot for putting this library together, it has saved me a lot of time.

I just found a small corner case in `toString` that I think it'd be great to change.

The default port 443 can be omited form the string url when the protocol is HTTPS.

I added a test case so you can verify this behavior. 

I'd really appreciate it if you could merge this change and release a new version. Let me know if you think I should change anything in this patch.

Signed-off-by: David Calavera <david.calavera@gmail.com>
  